### PR TITLE
Fix Garfield strip source

### DIFF
--- a/lib/redmine_tweaks/wiki_macros/garfield.rb
+++ b/lib/redmine_tweaks/wiki_macros/garfield.rb
@@ -39,16 +39,16 @@ module RedmineTweaks
     mm = date.strftime('%m')
     dd = date.strftime('%d')
     yy = date.strftime('%y')
-    type = date.sunday? ? 'jpg' : 'gif'
+    type = 'jpg'
     filename = 'ga' + yy + mm + dd
 
-    host = 'images.ucomics.com'
+    host = 'garfield.com'
     local_path = "#{Rails.root}/tmp/_garfield_#{filename}.#{type}"
 
     # cache file if it doesn't exist
     unless File.file?(local_path)
       Net::HTTP.start(host) do |http|
-        resp = http.get('/comics/ga/' + yyyy + '/' + filename + '.' + type)
+        resp = http.get('/uploads/strips/' + yyyy + '-' + mm + '-' + dd + '.' + type)
         unless resp.code == '404'
           open(local_path, 'wb') { |file| file.write(resp.body) }
         end

--- a/lib/redmine_tweaks/wiki_macros/garfield.rb
+++ b/lib/redmine_tweaks/wiki_macros/garfield.rb
@@ -40,7 +40,7 @@ module RedmineTweaks
     dd = date.strftime('%d')
     yy = date.strftime('%y')
     type = 'jpg'
-    filename = 'ga' + yy + mm + dd
+    filename = yyyy + '-' + mm + '-' + dd
 
     host = 'garfield.com'
     local_path = "#{Rails.root}/tmp/_garfield_#{filename}.#{type}"
@@ -48,7 +48,7 @@ module RedmineTweaks
     # cache file if it doesn't exist
     unless File.file?(local_path)
       Net::HTTP.start(host) do |http|
-        resp = http.get('/uploads/strips/' + yyyy + '-' + mm + '-' + dd + '.' + type)
+        resp = http.get('/uploads/strips/' + filename + '.' + type)
         unless resp.code == '404'
           open(local_path, 'wb') { |file| file.write(resp.body) }
         end


### PR DESCRIPTION
Since November 2015 Garfield strip is not available from: images.ucomics.com

works: http://images.ucomics.com/comics/ga/2015/ga151031.gif
Doesn't work: 
http://images.ucomics.com/comics/ga/2015/ga151101.gif | jpg
http://images.ucomics.com/comics/ga/2015/ga151102.gif | jpg
http://images.ucomics.com/comics/ga/2015/ga151201.gif | jpg
http://images.ucomics.com/comics/ga/2015/ga151222.gif | jpg